### PR TITLE
Add an example of lowercase hexadecimals

### DIFF
--- a/tutorial/02-the-mercury-type-system.polytex
+++ b/tutorial/02-the-mercury-type-system.polytex
@@ -51,11 +51,11 @@ overflow handling and so forth are dictated by the target machine.
 
 Fixed precision integers are represented by the #int# type.  Syntactically,
 an #int# is a sequence of digits, optionally preceded by a minus sign (there
-is no unary plus).  The sequence of digits may be decimal, hexadecimal (if
-preceded by #0x#), octal (if preceded by #0o#), or binary (if preceded by
-#0b#).
+is no unary plus).  The sequence of digits may be decimal, hexadecimal (both
+uppercase and lowercase are allowed, preceded by #0x#), octal (if preceded by
+#0o#), or binary (if preceded by #0b#).
 
-Examples: decimal #-123#, #0#, #42#; hexadecimal #-0x7B#, #0x0#, #0x2A#;
+Examples: decimal #-123#, #0#, #42#; hexadecimal #-0x7B#, #0x0#, #0x2a#;
 octal #-0o173#, #0o0#, #0o52#; binary #-0b1111011#, #0b0#, #0b101010#.
 
 The sequence #0'x# denotes the character code for the character #x#.  For


### PR DESCRIPTION
Being more descriptive of allowed hexadecimal literals