### PR TITLE
Add epub generation of tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@ decl_prog - Sources for "Declarative Programming in Mercury".
 tutorial - Sources for the Mercury tutorial book.
 
 It is available as a PDF on the [Mercury web site](http://mercurylang.org/).
+
+# Dependencies
+- Make
+- LaTeX
+- gawk
+- pandoc (for epub generation)
+
+## Install all on Debian
+- `apt install make gawk texlive-full pandoc`
+
+## Install all on MacOS/Homebrew:
+```sh
+brew install --cask mactex-no-gui
+brew install gawk pandoc
+```

--- a/tutorial/Makefile
+++ b/tutorial/Makefile
@@ -17,3 +17,6 @@ book.pdf: book.dvi
 	pdflatex book
 	pdflatex book
 	pdflatex book
+
+book.epub: book.dvi
+	pandoc book.tex -o $@


### PR DESCRIPTION
Epub works much better for non-print purposes, like e-readers, phones, et cetera. 

Please consider publishing the epub version on the Mercury website